### PR TITLE
Fix h2_client:send_request/3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _build
 rebar3
 .rebar3
 log
+.*.sw?

--- a/src/h2_connection.erl
+++ b/src/h2_connection.erl
@@ -257,7 +257,7 @@ get_peercert(Pid) ->
 is_push(Pid) ->
     gen_fsm:sync_send_all_state_event(Pid, is_push).
 
--spec new_stream(pid()) -> stream_id().
+-spec new_stream(pid()) -> stream_id() | {error, error_code()}.
 new_stream(Pid) ->
     new_stream(Pid, self()).
 
@@ -274,7 +274,7 @@ send_promise(Pid, StreamId, NewStreamId, Headers) ->
 
 -spec get_response(pid(), stream_id()) ->
                           {ok, {hpack:headers(), iodata()}}
-                              | {error, term()}.
+                           | not_ready.
 get_response(Pid, StreamId) ->
     gen_fsm:sync_send_all_state_event(Pid, {get_response, StreamId}).
 


### PR DESCRIPTION
h2_client:send_request/3 does not check the return from
h2_connection:new_stream/1,2. When a new stream cannot be created,
for example, because the peer connection sets the maximum concurrent
streams to 1, h2_connection:new_stream/1,2 returns {error, 7}.

However, because h2_client:send_request/3 does not check this,
it returns {ok, {error, 7}} to the caller, which blows up when it next
tries to use a stream id of {error, 7}.

This commit corrects this so that h2_client:send_request/3 returns
either {ok, stream_id()} or {error, error_code()}.

This commit also refactors sync_request/3 to call send_request/3, and
adds or corrects some type specs (such as the one for
h2_connection:new_stream/1).